### PR TITLE
Updated GitHub CI

### DIFF
--- a/.github/workflows/airtable_delete_database_entries_test.yml
+++ b/.github/workflows/airtable_delete_database_entries_test.yml
@@ -59,8 +59,10 @@ jobs:
           CI_AIRTABLE_TABLE: ${{secrets.CI_AIRTABLE_TABLE}}
           CI_DROPBOX_APP_KEY: ${{secrets.CI_DROPBOX_APP_KEY}}
           CI_DROPBOX_REFRESH_TOKEN: ${{secrets.CI_DROPBOX_REFRESH_TOKEN}}
-          
-        run: pytest tests/test_delete_database_entries.py -v -s --disable-warnings
+        # Reruns: intermittent Airtable HTTP 406 (security block) on GHA runners
+        run: >
+          pytest tests/test_delete_database_entries.py -v -s --disable-warnings
+          --reruns 5 --reruns-delay 6
 
       - name: Run empty Dropbox folder test
         env:

--- a/.github/workflows/airtable_image_upload_test.yml
+++ b/.github/workflows/airtable_image_upload_test.yml
@@ -52,13 +52,15 @@ jobs:
       - name: Install the necessary libraries to run airlift
         run: poetry install --no-root
 
-      - name: Run tests
+      - name: Run upload integration test
         env:
           CI_AIRTABLE_TOKEN: ${{secrets.CI_AIRTABLE_TOKEN}}
           CI_AIRTABLE_BASE: ${{secrets.CI_AIRTABLE_BASE}}
           CI_AIRTABLE_TABLE: ${{secrets.CI_AIRTABLE_TABLE}}
           CI_DROPBOX_APP_KEY: ${{secrets.CI_DROPBOX_APP_KEY}}
           CI_DROPBOX_REFRESH_TOKEN: ${{secrets.CI_DROPBOX_REFRESH_TOKEN}}
-          
-        run: pytest tests/test_upload.py -v -s --disable-warnings
+        # Reruns: intermittent Airtable HTTP 406 (security block) on GHA runners
+        run: >
+          pytest tests/test_upload.py -v -s --disable-warnings
+          --reruns 5 --reruns-delay 6
         

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 1.4.1
+
+**🎉 Released:**
+- 4th June 2026
+
+**🔨 Improvements:**
+- Scheduled Airtable integration workflows retry intermittent HTTP 406 responses (Airtable security block on some GitHub Actions datacenters; see [API troubleshooting](https://support.airtable.com/docs/airtable-api-common-troubleshooting)) via `pytest-rerunfailures` in CI
+
+---
+
 ### 1.4.0
 
 **🎉 Released:**

--- a/poetry.lock
+++ b/poetry.lock
@@ -657,6 +657,22 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "15.1"
+description = "pytest plugin to re-run tests to eliminate flaky failures"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_rerunfailures-15.1-py3-none-any.whl", hash = "sha256:f674c3594845aba8b23c78e99b1ff8068556cc6a8b277f728071fdc4f4b0b355"},
+    {file = "pytest_rerunfailures-15.1.tar.gz", hash = "sha256:c6040368abd7b8138c5b67288be17d6e5611b7368755ce0465dda0362c8ece80"},
+]
+
+[package.dependencies]
+packaging = ">=17.1"
+pytest = ">=7.4,<8.2.2 || >8.2.2"
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -836,4 +852,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "67de391a64b5a4bd6262f2af3ccb0a7ddd0d03376096daeb180e1dc451bea949"
+content-hash = "1b28f0024171f90f9de047db9abcb0ed1a7ecd3afa1e9347dc787544c6ad8361"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ pytest = "^9.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.0"
+pytest-rerunfailures = "^15.0"
 python-dotenv = "^1.0.0"
 
 [build-system]


### PR DESCRIPTION
- Added pytest-rerunfailures for to eliminate 406 flakey failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI test reliability by adding automatic retry logic for flaky integration tests.
  * Added a development dependency to enable test retry behavior.
* **Documentation**
  * Updated changelog with a new 1.4.1 entry (dated 4 June 2026) noting the CI reliability improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->